### PR TITLE
チャンネル名を設定ファイルから取り出す

### DIFF
--- a/app/convert-old-jsons-to-htmls.hs
+++ b/app/convert-old-jsons-to-htmls.hs
@@ -20,15 +20,17 @@ import           SlackLog.Html
 import           SlackLog.Types       (targetChannels)
 import           SlackLog.Util        (readJsonFile)
 import qualified System.Directory     as Dir
+import qualified Data.Yaml            as Yaml
 
 main :: IO ()
-main = Dir.withCurrentDirectory "docs" $ do
-  ws <- loadWorkspaceInfo "json"
-  logConfig <- readJsonFile "json/.config.json"
+main = do
+  logConfig <- Yaml.decodeFileThrow "slack-log.yaml"
+  Dir.withCurrentDirectory "docs" $ do
+    ws <- loadWorkspaceInfo logConfig "json"
 
-  namesByChannel <- for (HM.keys $ targetChannels logConfig) $ \chanId -> do
-    jsonPaths <- collectTargetJsons chanId
-    convertJsonsInChannel ws chanId jsonPaths
-    return (chanId, jsonPaths)
+    namesByChannel <- for (HM.keys $ targetChannels logConfig) $ \chanId -> do
+      jsonPaths <- collectTargetJsons chanId
+      convertJsonsInChannel ws chanId jsonPaths
+      return (chanId, jsonPaths)
 
-  generateIndexHtml ws namesByChannel
+    generateIndexHtml ws namesByChannel

--- a/package.yaml
+++ b/package.yaml
@@ -34,6 +34,7 @@ dependencies:
 - time
 - template-haskell
 - tz
+- yaml
 - unordered-containers
 - QuickCheck
 - quickcheck-instances

--- a/slack-log.yaml
+++ b/slack-log.yaml
@@ -1,0 +1,57 @@
+workspaceName: haskell-jp
+timeZone: Asia/Tokyo
+targetChannels:
+  CL3AXB1AL:
+    visibility: Public
+    label: atcoder-lang-updates
+  CR2TETE5R:
+    visibility: Public
+    label: beginners
+  C8KBGEBR7:
+    visibility: Public
+    label: code-review
+  C4P499EPQ:
+    visibility: Public
+    label: english
+  CR4U9PBLL:
+    visibility: Public
+    label: english-help
+  C4LFB6DE0:
+    visibility: Public
+    label: general
+  CAXQ09PN2:
+    visibility: Public
+    label: haskell-day
+  C7Y71415W:
+    visibility: Public
+    label: math
+  C5666B6BB:
+    visibility: Public
+    label: questions
+  C4M4TT8JJ:
+    visibility: Public
+    label: random
+  C8R0H137H:
+    visibility: Public
+    label: translation
+  CCYF8H43A:
+    visibility: Public
+    label: nix
+  CD87P78HF:
+    visibility: Public
+    label: mmlh
+  CE368SB5G:
+    visibility: Public
+    label: ghc8x
+  CGT2Q4KHP:
+    visibility: Public
+    label: hatchobori-haskell
+  CM4J6EDHR:
+    visibility: Public
+    label: icfp
+  CN3P057K8:
+    visibility: Public
+    label: haskell-day-sponsor
+  GDTFWM8KX:
+    visibility: Private
+    label: haskell-day-staff

--- a/src/SlackLog/Types.hs
+++ b/src/SlackLog/Types.hs
@@ -24,22 +24,16 @@ data Config = Config
   --   from Slack: not only when converting JSON files into HTML.
   } deriving (Eq, Show, Generic, Json.FromJSON)
 
+data TargetChannel = TargetChannel
+  { visibility :: Visibility
+  , label :: T.Text
+  } deriving (Show, Eq, Generic)
+instance Json.FromJSON TargetChannel
 
-data Visibility = Private | Public deriving (Eq, Show)
+data Visibility = Private | Public deriving (Eq, Show, Generic)
+instance Json.FromJSON Visibility
 
-instance Json.FromJSON Visibility where
-  parseJSON = JsonTypes.withText typ $ \t -> do
-    let err = JsonTypes.typeMismatch "Visibility" (JsonTypes.String t)
-    -- Parse only the first word of the text to allow users to leave comments.
-    firstWord <- maybe err pure . headMay $ T.words t
-    case firstWord of
-        "Private" -> pure Private
-        "Public"  -> pure Public
-        _         -> err
-   where
-    typ = "Visibility"
-
-type TargetChannels = HM.HashMap ChannelId Visibility
+type TargetChannels = HM.HashMap ChannelId TargetChannel
 
 type UserName = T.Text
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.29
+resolver: lts-14.20
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 500539
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/29.yaml
-    sha256: 006398c5e92d1d64737b7e98ae4d63987c36808814504d1451f56ebd98093f75
-  original: lts-13.29
+    size: 524154
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/20.yaml
+    sha256: 2f5099f69ddb6abfe64400fe1e6a604e8e628f55e6837211cd70a81eb0a8fa4d
+  original: lts-14.20


### PR DESCRIPTION
いくつかの破壊的変更が含まれています。

* .config.json → slack-log.yaml (ファイル名とフォーマットの変更)
* visibilityとlabelをフィールドとして持つTargetChannel型を追加