### PR TITLE
Truncate messages in index.html

### DIFF
--- a/src/SlackLog/Html.hs
+++ b/src/SlackLog/Html.hs
@@ -243,7 +243,7 @@ renderIndexOfPages wsi@WorkspaceInfo {..} =
             (timestampWords $ Slack.slackTimestampTime messageTs)
           )
         # H.div_A (A.class_ "page__first_message__body description")
-          (truncatedMessage messageText)
+          (unescapeHtmlEntities $ truncatedMessage messageText)
         )
       )
 
@@ -268,6 +268,12 @@ truncatedMessage Slack.SlackMessageText { unSlackMessageText = msg }
   | T.length msg > truncatedMessageMaxLength
   = T.take truncatedMessageMaxLength msg <> T.pack "..."
   | otherwise = msg
+
+unescapeHtmlEntities :: T.Text -> T.Text
+unescapeHtmlEntities =
+  T.replace (T.pack "&lt;") (T.pack "<")
+  . T.replace (T.pack "&gt;") (T.pack ">")
+  . T.replace (T.pack "&amp;") (T.pack "&")
 
 ensurePathIn :: String -> ChannelId -> FilePath -> FilePath
 ensurePathIn typ cid name = typ ++ "/" ++ T.unpack cid ++ "/" ++ takeBaseName name <.> typ

--- a/src/SlackLog/Html.hs
+++ b/src/SlackLog/Html.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE NamedFieldPuns    #-}
-{-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE StrictData        #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns   #-}
+{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE StrictData       #-}
 
 -- | Assumes functions in this module are executed in doc/ directory
 
@@ -42,7 +42,7 @@ import qualified Web.Slack.Common        as Slack
 import qualified Web.Slack.MessageParser as Slack
 
 import           SlackLog.Types          (ChannelId, ChannelName, Config (..),
-                                          UserId, UserName, TargetChannel(..))
+                                          TargetChannel (..), UserId, UserName)
 import           SlackLog.Util           (failWhenLeft, readJsonFile)
 
 
@@ -54,11 +54,11 @@ data PageInfo = PageInfo
   } deriving (Eq, Show)
 
 data WorkspaceInfo = WorkspaceInfo
-  { userNameById          :: HM.HashMap UserId UserName
-  , channelNameById       :: HM.HashMap ChannelId ChannelName
-  , groupNameById         :: HM.HashMap ChannelId ChannelName
-  , workspaceInfoName     :: T.Text
-  , getTimeDiff           :: TC.UTCTime -> LT.TimeZone
+  { userNameById      :: HM.HashMap UserId UserName
+  , channelNameById   :: HM.HashMap ChannelId ChannelName
+  , groupNameById     :: HM.HashMap ChannelId ChannelName
+  , workspaceInfoName :: T.Text
+  , getTimeDiff       :: TC.UTCTime -> LT.TimeZone
   }
 
 
@@ -243,7 +243,7 @@ renderIndexOfPages wsi@WorkspaceInfo {..} =
             (timestampWords $ Slack.slackTimestampTime messageTs)
           )
         # H.div_A (A.class_ "page__first_message__body description")
-          (mkTruncatedMessage messageText)
+          (truncatedMessage messageText)
         )
       )
 
@@ -263,8 +263,8 @@ mkMessageBody =
 
 truncatedMessageMaxLength = 300
 
-mkTruncatedMessage :: Slack.SlackMessageText -> T.Text
-mkTruncatedMessage Slack.SlackMessageText { unSlackMessageText = msg }
+truncatedMessage :: Slack.SlackMessageText -> T.Text
+truncatedMessage Slack.SlackMessageText { unSlackMessageText = msg }
   | T.length msg > truncatedMessageMaxLength
   = T.take truncatedMessageMaxLength msg <> T.pack "..."
   | otherwise = msg

--- a/src/SlackLog/Html.hs
+++ b/src/SlackLog/Html.hs
@@ -243,7 +243,7 @@ renderIndexOfPages wsi@WorkspaceInfo {..} =
             (timestampWords $ Slack.slackTimestampTime messageTs)
           )
         # H.div_A (A.class_ "page__first_message__body description")
-          (H.Raw $ mkMessageBody wsi messageText)
+          (mkTruncatedMessage messageText)
         )
       )
 
@@ -257,11 +257,17 @@ renderIndexOfPages wsi@WorkspaceInfo {..} =
     let lt = LT.utcToZonedTime (getTimeDiff tm) tm
     in TF.formatTime TF.defaultTimeLocale "%Y-%m-%d %T %z" lt
 
-
 mkMessageBody :: WorkspaceInfo -> Slack.SlackMessageText -> T.Text
 mkMessageBody =
   Slack.messageToHtml Slack.defaultHtmlRenderers . getUserName
 
+truncatedMessageMaxLength = 300
+
+mkTruncatedMessage :: Slack.SlackMessageText -> T.Text
+mkTruncatedMessage Slack.SlackMessageText { unSlackMessageText = msg }
+  | T.length msg > truncatedMessageMaxLength
+  = T.take truncatedMessageMaxLength msg <> T.pack "..."
+  | otherwise = msg
 
 ensurePathIn :: String -> ChannelId -> FilePath -> FilePath
 ensurePathIn typ cid name = typ ++ "/" ++ T.unpack cid ++ "/" ++ takeBaseName name <.> typ

--- a/src/SlackLog/Html.hs
+++ b/src/SlackLog/Html.hs
@@ -261,7 +261,7 @@ mkMessageBody :: WorkspaceInfo -> Slack.SlackMessageText -> T.Text
 mkMessageBody =
   Slack.messageToHtml Slack.defaultHtmlRenderers . getUserName
 
-truncatedMessageMaxLength = 300
+truncatedMessageMaxLength = 150
 
 truncatedMessage :: Slack.SlackMessageText -> T.Text
 truncatedMessage Slack.SlackMessageText { unSlackMessageText = msg }


### PR DESCRIPTION
https://github.com/haskell-jp/slack-log/issues/26

issue内の通り、truncateする際のslackのメッセージフォーマットの扱いには選択の余地が有りましたが、生のslackのformatをescapeするだけにしました。

その結果としては次のような点が気になるとは思いました。
- ユーザー名を解決していない
- 元メッセージでの`<`等は2重でエスケープされる
- emoji

とはいえ、概要としては十分かもしれないです。