### PR TITLE
haskell/actions/setup を利用して GitHub Actions の設定を修正

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,23 +14,29 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, windows-2019]
+        ghc: ["8.10.3"] # stack.yamlのresolverに合わせて更新してください
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Cache .stack
       id: cache-stack
-      uses: actions/cache@v1.1.2
+      uses: actions/cache@v2.1.4
       with:
         path: ~/.stack
         key: ${{ runner.os }}-stack-${{ hashFiles('**/package.yaml') }}-${{ hashFiles('**/stack.yaml.lock') }}
         restore-keys: |
           ${{ runner.os }}-stack-
 
-    - uses: mstksg/setup-stack@v2
+    - uses: haskell/actions/setup@v1.1.7
+      name: Setup Haskell
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        enable-stack: true
+        stack-version: 'latest'
 
     - name: Install dependencies
-      run: stack test --only-dependencies
+      run: stack --system-ghc test --only-dependencies
 
     - name: Run test
-      run: stack test --pedantic
+      run: stack --system-ghc test --pedantic


### PR DESCRIPTION
GitHub Actions を導入当時、setup-haskell は Stack が入ってなかったっぽく、そのために https://github.com/mstksg/setup-stack を利用していました。
このアクションは新しい GitHub Actions の使用（add-path が使えない）に追従していないためずっとエラーが出ていたようです。

そもそも、setup-haskell に stack を同梱する設定が追加されたので、setup-haskell (を移植した [haskell/actions/setup](https://github.com/haskell/actions)) を代わりに利用するように修正しました。

ついでに
- actions/cache のバージョンを上げました（特にバージョンをあげたことでの恩恵はありませんが）
- stack build するときに `--system-ghc` オプションを指定するようにしました
    - stack.yaml の resolver に合わせた GHC を setup-haskell で入れておくことでCI/CDの高速化ができます 